### PR TITLE
Use Responses API shape end-to-end (backend + frontend + tests)

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "werkzeug",
     "gunicorn",
     "uvicorn[standard]",
-    "openai>=1.108.1",
+    "openai>=1.126.0",
     "azure-identity",
     "azure-keyvault-secrets",
     "aiohttp",

--- a/src/quartapp/chat.py
+++ b/src/quartapp/chat.py
@@ -108,30 +108,21 @@ async def index():
 
 @bp.post("/chat/stream")
 async def chat_handler():
-    request_messages = (await request.get_json())["messages"]
+    request_input = (await request.get_json())["input"]
 
     @stream_with_context
     async def response_stream():
-        # This sends all messages, so API request may exceed token limits
-        all_messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-        ] + request_messages
-
-        chat_coroutine = bp.openai_client.responses.create(
-            model=bp.openai_model_arg,
-            input=all_messages,
-            max_output_tokens=1000,
-            stream=True,
-            store=False,
-        )
         try:
-            async for event in await chat_coroutine:
-                if event.type == "response.output_text.delta":
-                    yield json.dumps({"delta": {"content": event.delta}}, ensure_ascii=False) + "\n"
-                elif event.type == "response.completed":
-                    yield json.dumps({"delta": {"content": None}, "finish_reason": "stop"}, ensure_ascii=False) + "\n"
+            async with bp.openai_client.responses.stream(
+                model=bp.openai_model_arg,
+                input=request_input,
+                store=False,
+            ) as openai_stream:
+                async for event in openai_stream:
+                    if event.type == "response.output_text.delta":
+                        yield json.dumps(event.model_dump(), ensure_ascii=False) + "\n"
         except Exception as e:
-            current_app.logger.error(e)
+            current_app.logger.exception("Responses stream failed")
             yield json.dumps({"error": str(e)}, ensure_ascii=False) + "\n"
 
-    return Response(response_stream())
+    return Response(response_stream(), mimetype="application/x-ndjson")

--- a/src/quartapp/templates/index.html
+++ b/src/quartapp/templates/index.html
@@ -89,7 +89,13 @@
         const userTemplate = document.querySelector('#message-template-user');
         const assistantTemplate = document.querySelector('#message-template-assistant');
         const converter = new showdown.Converter();
-        const messages = [];
+        const messages = [
+            {
+                type: "message",
+                role: "system",
+                content: [{ type: "input_text", text: "You are a helpful assistant." }]
+            }
+        ];
 
         form.addEventListener("submit", async function(e) {
             e.preventDefault();
@@ -104,41 +110,50 @@
             targetContainer.appendChild(assistantTemplateClone);
 
             messages.push({
-                "role": "user",
-                "content": message
+                type: "message",
+                role: "user",
+                content: [{ type: "input_text", text: message }]
             });
 
-            const response = await fetch("/chat/stream", {
-                method: "POST",
-                headers: {"Content-Type": "application/json"},
-                body: JSON.stringify({messages}),
-            });
+            try {
+                const response = await fetch("/chat/stream", {
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify({ input: messages }),
+                });
 
-            let answer = "";
-            for await (const chunk of readNDJSONStream(response.body)) {
-                if (chunk.error) {
-                    messageDiv.innerHTML = "Error: " + chunk.error;
-                    break;
+                if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`);
                 }
-                if (!chunk.delta) {
-                    continue;
+
+                if (!response.body) {
+                    throw new Error("Streaming response body was empty.");
                 }
-                if (chunk.delta.content) {
-                    if (answer == "") {
-                        messageDiv.innerHTML = "";
+
+                let answer = "";
+                for await (const chunk of readNDJSONStream(response.body)) {
+                    if (chunk.type === "response.output_text.delta" && chunk.delta) {
+                        if (answer == "") {
+                            messageDiv.innerHTML = "";
+                        }
+                        answer += chunk.delta;
+                        messageDiv.innerHTML = converter.makeHtml(answer);
+                        messageDiv.scrollIntoView();
                     }
-                    answer += chunk.delta.content;
-                    messageDiv.innerHTML = converter.makeHtml(answer);
-                    messageDiv.scrollIntoView();
+                    if (chunk.error) {
+                        messageDiv.innerHTML = "Error: " + chunk.error;
+                    }
                 }
+                messages.push({
+                    type: "message",
+                    role: "assistant",
+                    content: [{ type: "output_text", text: answer }]
+                });
+
+                messageInput.value = "";
+            } catch (error) {
+                messageDiv.innerHTML = "Error: " + error;
             }
-
-            messages.push({
-                "role": "assistant",
-                "content": answer
-            });
-
-            messageInput.value = "";
         });
     </script>
 </body>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import dataclass
 from unittest import mock
 
 import pytest
@@ -11,46 +12,70 @@ from . import mock_cred
 
 
 @pytest.fixture
-def mock_openai_responses(monkeypatch):
+def mock_openai_responses_stream(monkeypatch):
+    @dataclass
     class MockResponseEvent:
-        """Simulates a Responses API streaming event."""
+        type: str
+        delta: str | None = None
 
-        def __init__(self, event_type, delta=None):
-            self.type = event_type
-            self.delta = delta
+        def model_dump(self) -> dict[str, str]:
+            payload = {"type": self.type}
+            if self.delta is not None:
+                payload["delta"] = self.delta
+            return payload
 
-    class AsyncResponseIterator:
+    class AsyncResponseStream:
         def __init__(self, answer: str):
-            self.event_index = 0
-            self.events = []
-            answer_deltas = answer.split(" ")
-            for i, word in enumerate(answer_deltas):
-                if i > 0:
-                    word = " " + word
-                self.events.append(MockResponseEvent("response.output_text.delta", delta=word))
-            self.events.append(MockResponseEvent("response.completed"))
+            self._chunk_index = 0
+            self._chunks = []
+            for answer_index, answer_delta in enumerate(answer.split(" ")):
+                if answer_index > 0:
+                    answer_delta = " " + answer_delta
+                self._chunks.append(MockResponseEvent(type="response.output_text.delta", delta=answer_delta))
 
         def __aiter__(self):
             return self
 
         async def __anext__(self):
-            if self.event_index < len(self.events):
-                event = self.events[self.event_index]
-                self.event_index += 1
-                return event
-            else:
-                raise StopAsyncIteration
+            if self._chunk_index < len(self._chunks):
+                next_chunk = self._chunks[self._chunk_index]
+                self._chunk_index += 1
+                return next_chunk
+            raise StopAsyncIteration
 
-    async def mock_acreate(*args, **kwargs):
-        last_message = kwargs.get("input", [])[-1]["content"]
+    class AsyncResponseStreamManager:
+        def __init__(self, answer: str):
+            self._stream = AsyncResponseStream(answer)
+
+        async def __aenter__(self):
+            return self._stream
+
+        async def __aexit__(self, exc_type, exc, exc_tb):
+            return None
+
+    def mock_stream(*args, **kwargs):
+        response_input = kwargs.get("input")
+        last_message = response_input[-1]["content"][0]["text"]
+
+        assert response_input[0] == {
+            "type": "message",
+            "role": "system",
+            "content": [{"type": "input_text", "text": "You are a helpful assistant."}],
+        }
+
+        if len(response_input) > 2:
+            assistant_message = response_input[-2]
+            assert assistant_message["role"] == "assistant"
+            assert assistant_message["content"][0]["type"] == "output_text"
+
+        assert kwargs.get("store") is False
         if last_message == "What is the capital of France?":
-            return AsyncResponseIterator("The capital of France is Paris.")
-        elif last_message == "What is the capital of Germany?":
-            return AsyncResponseIterator("The capital of Germany is Berlin.")
-        else:
-            raise ValueError(f"Unexpected message: {last_message}")
+            return AsyncResponseStreamManager("The capital of France is Paris.")
+        if last_message == "What is the capital of Germany?":
+            return AsyncResponseStreamManager("The capital of Germany is Berlin.")
+        raise ValueError(f"Unexpected message: {last_message}")
 
-    monkeypatch.setattr("openai.resources.responses.AsyncResponses.create", mock_acreate)
+    monkeypatch.setattr("openai.resources.responses.responses.AsyncResponses.stream", mock_stream)
 
 
 @pytest.fixture
@@ -73,7 +98,7 @@ def mock_keyvault_secretclient(monkeypatch):
 
 
 @pytest_asyncio.fixture
-async def client(monkeypatch, mock_openai_responses, mock_defaultazurecredential):
+async def client(monkeypatch, mock_openai_responses_stream, mock_defaultazurecredential):
     with mock.patch.dict(os.environ, clear=True):
         monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "test-openai-service.openai.azure.com")
         monkeypatch.setenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "gpt-5.2")

--- a/tests/snapshots/test_app/test_chat_stream_text/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_stream_text/result.jsonlines
@@ -1,7 +1,6 @@
-{"delta": {"content": "The"}}
-{"delta": {"content": " capital"}}
-{"delta": {"content": " of"}}
-{"delta": {"content": " France"}}
-{"delta": {"content": " is"}}
-{"delta": {"content": " Paris."}}
-{"delta": {"content": null}, "finish_reason": "stop"}
+{"type": "response.output_text.delta", "delta": "The"}
+{"type": "response.output_text.delta", "delta": " capital"}
+{"type": "response.output_text.delta", "delta": " of"}
+{"type": "response.output_text.delta", "delta": " France"}
+{"type": "response.output_text.delta", "delta": " is"}
+{"type": "response.output_text.delta", "delta": " Paris."}

--- a/tests/snapshots/test_app/test_chat_stream_text_history/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_stream_text_history/result.jsonlines
@@ -1,7 +1,6 @@
-{"delta": {"content": "The"}}
-{"delta": {"content": " capital"}}
-{"delta": {"content": " of"}}
-{"delta": {"content": " Germany"}}
-{"delta": {"content": " is"}}
-{"delta": {"content": " Berlin."}}
-{"delta": {"content": null}, "finish_reason": "stop"}
+{"type": "response.output_text.delta", "delta": "The"}
+{"type": "response.output_text.delta", "delta": " capital"}
+{"type": "response.output_text.delta", "delta": " of"}
+{"type": "response.output_text.delta", "delta": " Germany"}
+{"type": "response.output_text.delta", "delta": " is"}
+{"type": "response.output_text.delta", "delta": " Berlin."}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,8 +20,17 @@ async def test_chat_stream_text(client, snapshot):
     response = await client.post(
         "/chat/stream",
         json={
-            "messages": [
-                {"role": "user", "content": "What is the capital of France?"},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": "You are a helpful assistant."}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "What is the capital of France?"}],
+                },
             ]
         },
     )
@@ -35,10 +44,27 @@ async def test_chat_stream_text_history(client, snapshot):
     response = await client.post(
         "/chat/stream",
         json={
-            "messages": [
-                {"role": "user", "content": "What is the capital of France?"},
-                {"role": "assistant", "content": "Paris"},
-                {"role": "user", "content": "What is the capital of Germany?"},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": "You are a helpful assistant."}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "What is the capital of France?"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Paris"}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "What is the capital of Germany?"}],
+                },
             ]
         },
     )


### PR DESCRIPTION
## Summary

Migrates the frontend and backend to use the Responses API event shape end-to-end, matching the pattern in [openai-chat-app-entra-auth-local#78](https://github.com/Azure-Samples/openai-chat-app-entra-auth-local/pull/78). Previously the backend translated Responses API events into a legacy `{"delta": {"content": ...}}` shape; now the raw Responses API events are streamed directly to the frontend.

## Changes

### Backend — `src/quartapp/chat.py`
- Accept `input` (Responses API item format) from the frontend instead of `messages` (Chat Completions format)
- Switch from `responses.create(..., stream=True)` to `responses.stream()` context manager
- Stream only `response.output_text.delta` events via `event.model_dump()` instead of wrapping in `{"delta": {"content": ...}}`
- Remove server-side system prompt injection (now sent by the frontend in the `input` array)
- Set `mimetype="application/x-ndjson"` on the response

### Frontend — `src/quartapp/templates/index.html`
- Messages use Responses API item format: `{type: "message", role: ..., content: [{type: "input_text", text: ...}]}`
- System prompt initialized client-side in the `messages` array
- POST body sends `{input: messages}` instead of `{messages: messages}`
- Stream processing reads `chunk.type === "response.output_text.delta"` and `chunk.delta` instead of `chunk.delta.content`
- Assistant messages stored as `{type: "output_text", text: answer}`
- Added error handling for non-OK responses and empty response body

### Tests — `tests/conftest.py`, `tests/test_app.py`
- Mock uses `AsyncResponseStreamManager` context manager matching `responses.stream()`
- Mock validates Responses API `input` format with structured content items
- Monkeypatch path: `openai.resources.responses.responses.AsyncResponses.stream`
- Tests send `input` array with `{type: "message", ...}` items
- Fixture renamed `mock_openai_responses` → `mock_openai_responses_stream`

### Snapshots
- Updated content from `{"delta": {"content": "..."}}` to `{"type": "response.output_text.delta", "delta": "..."}`

### Dependencies — `src/pyproject.toml`
- Bumped `openai>=1.108.1` → `openai>=1.126.0`